### PR TITLE
Handle Etc.getlogin returning nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Fixed
 
-- <PR-#5>: https://github.com/magiclabs/magic-admin-ruby/issues/5
+- <PR-#ISSUE> ...
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Fixed
 
-- <PR-#ISSUE> ...
+- <PR-#5>: https://github.com/magiclabs/magic-admin-ruby/issues/5
 
 #### Changed
 
@@ -15,3 +15,9 @@
 #### Changed
 
 - <PR-#ISSUE> ...
+
+## `0.1.2` - 10/30/2020
+
+#### Changed
+
+- <PR-#5>: https://github.com/magiclabs/magic-admin-ruby/issues/5

--- a/lib/magic-admin/config.rb
+++ b/lib/magic-admin/config.rb
@@ -37,7 +37,11 @@ module MagicAdmin
     # Returns:
     #   installation machine user_name
     def self.user_name
-      Etc.getpwnam(Etc.getlogin).gecos.split(/,/).first
+      login = Etc.getlogin
+
+      return "None" if login.nil?
+
+      Etc.getpwnam(login).gecos.split(/,/).first
     end
 
     # Description:

--- a/lib/magic-admin/version.rb
+++ b/lib/magic-admin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MagicAdmin
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
### 📦 Pull Request

Default to `None` if `Etc.getlogin()` returns `nil`.

### 🗜 Versioning

(Check _one!_)

- [x] Patch: Bug Fix?
- [ ] Minor: New Feature?
- [ ] Major: Breaking Change?

### ✅ Fixed Issues

- https://github.com/magiclabs/magic-admin-ruby/issues/5

### 🚨 Test instructions

- `bundle exec rspec` is green
- Manually verification

### ⚠️ Update `CHANGELOG.md`

- [x] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
