### PR TITLE
gems: bump eth to 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### Fixed
 
-- <PR-#ISSUE> ...
+- <PR-#12> https://github.com/magiclabs/magic-admin-ruby/issues/7
+- <PR-#12> https://github.com/magiclabs/magic-admin-ruby/issues/8
+- <PR-#12> https://github.com/magiclabs/magic-admin-ruby/issues/11
 
 #### Changed
 

--- a/lib/magic-admin/resource/token.rb
+++ b/lib/magic-admin/resource/token.rb
@@ -20,7 +20,7 @@ module MagicAdmin
       def validate(did_token)
         time = Time.now.to_i
         proof, claim = decode(did_token)
-        rec_address = rec_pub_address(claim, proof)
+        rec_address = rec_pub_address(claim, proof).to_s
 
         validate_public_address!(rec_address, did_token)
         validate_claim_fields!(claim)
@@ -97,11 +97,11 @@ module MagicAdmin
       end
 
       def personal_recover(claim, proof)
-        Eth::Key.personal_recover(JSON.dump(claim), proof)
+        Eth::Signature.personal_recover(JSON.dump(claim), proof)
       end
 
       def rec_pub_address(claim, proof)
-        Eth::Utils.public_key_to_address personal_recover(claim, proof)
+        Eth::Util.public_key_to_address personal_recover(claim, proof)
       end
 
       def claim_fields

--- a/magic-admin.gemspec
+++ b/magic-admin.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.metadata = {
   }
 
-  s.add_dependency "eth", "~> 0.4"
+  s.add_dependency "eth", "~> 0.5"
   s.add_development_dependency "byebug", "~> 11.0"
   s.add_development_dependency "rspec", "~> 3.9"
   s.add_development_dependency "rubocop", "~> 0.80"


### PR DESCRIPTION
### 📦 Pull Request

Updating the `Eth::` namespace to the changes introduced in 0.5

See https://github.com/q9f/eth.rb/releases

### 🗜 Versioning

- [x] Patch: Bug Fix?
- [ ] Minor: New Feature?
- [ ] Major: Breaking Change?

### ✅ Fixed Issues

Closes #7 

Closes #8

Closes #11

### 🚨 Test instructions

### ⚠️ Update `CHANGELOG.md`

- [x] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
