### PR TITLE
`Token#validate`: restore string conversion and fix test

### DIFF
--- a/lib/magic-admin/resource/token.rb
+++ b/lib/magic-admin/resource/token.rb
@@ -20,7 +20,7 @@ module MagicAdmin
       def validate(did_token)
         time = Time.now.to_i
         proof, claim = decode(did_token)
-        rec_address = rec_pub_address(claim, proof)
+        rec_address = rec_pub_address(claim, proof).to_s
 
         validate_public_address!(rec_address, did_token)
         validate_claim_fields!(claim)

--- a/test/resource/token_test.rb
+++ b/test/resource/token_test.rb
@@ -7,7 +7,7 @@ describe MagicAdmin::Resource::Token do
     describe "public methods" do
       it "#validate" do
         claim = { "ext" => 1000, "nbf" => "nbf" }
-        rec_address = double("rec_address")
+        rec_address = double("rec_address").to_s
         proof = double("proof")
         time_now = 1_202_020
         allow(Time).to receive(:now).and_return(time_now)


### PR DESCRIPTION
### 📦 Pull Request

Restore `to_s` string conversion in the `Token#validate` method. Also fixes tests by applying the same `to_s` string conversion to the test value.

### 🗜 Versioning

(Check _one!_)

- [x] Patch: Bug Fix?
- [ ] Minor: New Feature?
- [ ] Major: Breaking Change?

### ✅ Fixed Issues

- Fixes #15 

### 🚨 Test instructions

`bundle exec rspec`

### ⚠️ Update `CHANGELOG.md`

- [ ] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
