### PR TITLE
Validate aud in DID token. Pull client ID if not passed in constructor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
 
 - <PR-#ISSUE> ...
 
+## `1.0.0` - 7/5/2023
+
+#### Added
+
+- <PR-#20> Add Magic Connect Admin SDK support for Token Resource
+  - [Security Enhancement]: Validate `aud` using Magic client ID. 
+  - Pull client ID from Magic servers if not provided in constructor.
+
 ## `0.2.0` - 11/23/2022
 
 #### Added

--- a/lib/magic-admin/resource/token.rb
+++ b/lib/magic-admin/resource/token.rb
@@ -9,6 +9,24 @@ module MagicAdmin
     # It provides methods to interact with the DID Token.
     class Token
 
+      # attribute reader for magic client object
+      attr_reader :magic
+
+      # The constructor allows you to create a token object
+      # when your application interacting with the Magic API
+      #
+      # Arguments:
+      #   magic: A Magic object.
+      #
+      # Returns:
+      #   A token object that provides access to all the supported resources.
+      #
+      # Examples:
+      #   Token.new(<magic>)
+      def initialize(magic)
+        @magic = magic
+      end
+
       # Description:
       #   Method validate did_token
       #
@@ -26,6 +44,7 @@ module MagicAdmin
         validate_claim_fields!(claim)
         validate_claim_ext!(time, claim["ext"])
         validate_claim_nbf!(time, claim["nbf"])
+        validate_claim_aud!(magic.client_id, claim["aud"])
       end
 
       # Description:
@@ -141,6 +160,15 @@ module MagicAdmin
         raise DIDTokenError, message
       end
 
+      def validate_claim_aud!(client_id, claim_aud)
+        
+        return true unless client_id != claim_aud
+
+        message = "Audience does not match client ID. Please ensure your secret key matches the application which generated the DID token."
+        raise DIDTokenError, message
+      end
+
     end
   end
 end
+

--- a/lib/magic-admin/version.rb
+++ b/lib/magic-admin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MagicAdmin
-  VERSION = "0.2.0"
+  VERSION = "1.0.0"
 end

--- a/test/magic_test.rb
+++ b/test/magic_test.rb
@@ -4,7 +4,17 @@ require "spec_helper"
 
 describe Magic do
   let(:env_secret_key) { "<ENV_MAGIC_API_SECRET_KEY>" }
-  let(:agr_secret_key) { "<ARG_MAGIC_API_SECRET_KEY>" }
+  let(:arg_secret_key) { "<ARG_MAGIC_API_SECRET_KEY>" }
+
+  let(:env_client_id) { "<ENV_MAGIC_CLIENT_ID>" }
+  let(:arg_client_id) { "<ARG_MAGIC_CLIENT_ID>" }
+  let(:returned_client_id) { "<RETURNED_CLIENT_ID>" }
+
+  before(:each) do
+    allow_any_instance_of(MagicAdmin::Http::Client).to receive(:call).and_return(
+      double(data: { data: { client_id: returned_client_id } })
+    )
+  end
 
   describe "magic object without arguments and environment variables" do
     it "should raise an error" do
@@ -20,14 +30,14 @@ describe Magic do
     end
 
     it "should be set with arguments" do
-      magic = Magic.new(api_secret_key: agr_secret_key)
-      expect(magic.secret_key).to eq(agr_secret_key)
+      magic = Magic.new(api_secret_key: arg_secret_key)
+      expect(magic.secret_key).to eq(arg_secret_key)
     end
 
     it "should be set with arguments ignore environment variable" do
       ENV["MAGIC_API_SECRET_KEY"] = env_secret_key
-      magic = Magic.new(api_secret_key: agr_secret_key)
-      expect(magic.secret_key).to eq(agr_secret_key)
+      magic = Magic.new(api_secret_key: arg_secret_key)
+      expect(magic.secret_key).to eq(arg_secret_key)
       expect(magic.secret_key).not_to eq(env_secret_key)
     end
   end
@@ -119,6 +129,47 @@ describe Magic do
         http_client = Magic.new(backoff: arg_backoff).http_client
         expect(http_client.backoff).to eq(arg_backoff)
       end
+    end
+  end
+
+  describe "magic object set client_id" do
+
+    let(:api_secret_key) { "<API_SECRET_KEY>" }
+    
+    before(:each) do
+      ENV["MAGIC_API_SECRET_KEY"] = api_secret_key
+    end
+
+    it "should be set with environment variable" do
+      ENV["MAGIC_CLIENT_ID"] = env_client_id
+      magic = Magic.new
+      expect(magic.client_id).to eq(env_client_id)
+    end
+
+    it "should be set with argument" do
+      ENV["MAGIC_CLIENT_ID"] = nil
+      magic = Magic.new(client_id: arg_client_id)
+      expect(magic.client_id).to eq(arg_client_id)
+    end
+
+    it "should be set with argument ignore environment variable" do
+      ENV["MAGIC_CLIENT_ID"] = env_client_id
+      magic = Magic.new(client_id: arg_client_id)
+      expect(magic.client_id).to eq(arg_client_id)
+      expect(magic.client_id).not_to eq(env_client_id)
+    end
+
+    it "should retrieve from API if not set" do
+      ENV["MAGIC_CLIENT_ID"] = nil
+      magic = Magic.new
+      expect(magic.client_id).to eq(returned_client_id)
+    end
+
+    it "should raise an error if API key is invalid" do
+      allow_any_instance_of(MagicAdmin::Http::Client).to receive(:call).and_return(
+        double(data: { data: { } })
+      )
+      expect { Magic.new }.to raise_exception MagicAdmin::MagicError
     end
   end
 end

--- a/test/resource/user_test.rb
+++ b/test/resource/user_test.rb
@@ -3,17 +3,17 @@
 require "spec_helper"
 
 describe MagicAdmin::Resource::User do
-  let(:magic) { Magic.new(api_secret_key: spec_api_secret_key) }
+  let(:magic) { Magic.new(api_secret_key: spec_api_secret_key, client_id: spec_client_id) }
   let(:public_address) do
-    MagicAdmin::Resource::Token.new.get_public_address(spec_did_token)
+    MagicAdmin::Resource::Token.new(magic).get_public_address(spec_did_token)
   end
 
   let(:issuer) do
-    MagicAdmin::Resource::Token.new.get_issuer(spec_did_token)
+    MagicAdmin::Resource::Token.new(magic).get_issuer(spec_did_token)
   end
 
   let(:construct_issuer_with_public_address) do
-    MagicAdmin::Resource::Token.new.construct_issuer_with_public_address(public_address)
+    MagicAdmin::Resource::Token.new(magic).construct_issuer_with_public_address(public_address)
   end
 
   let(:stub_response_body) do

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -46,3 +46,6 @@ def spec_api_secret_key
   "sk_test_TESTTESTTESTTEST"
 end
 
+def spec_client_id
+  "clientId12345="
+end


### PR DESCRIPTION
### 📦 Pull Request

Validate `aud` against Magic client ID. Pull client ID from API secret key if not present in constructor.

### 🗜 Versioning

(Check _one!_)

- [ ] Patch: Bug Fix?
- [ ] Minor: New Feature?
- [x] Major: Breaking Change?

### ✅ Fixed Issues

- Adds `aud` validation by checking that it matches client ID
- Pulls client ID from Magic servers if not provided.

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

Tested in my environment with the following file (varied the args + client ID) to ensure the following test cases worked:
1. MA Client ID pulled from Magic -> validated DID token
2. MA Client ID passed in from args -> validated DID token
3. MA Client ID mismatch -> raised error

```
require 'bundler'
Bundler.require

require_relative './lib/magic-admin'

magic = Magic.new(api_secret_key: 'SECRET KEY')
magic.token.validate('WyIweDNiMjA5ZDhjZjYwZmM5MWY2ZGI0MjhjMTM3M2EwOGZhZjI1YTM4NWViZTVlZGVjYjA4NDg4YjE3YTg0NTYzMmEyYmZiZDM4MjdmZmU4Y2ZhMzEyYTI5YzE1NzM5MmE5ZTFlMmRmMGRiZmYwZmJlN2Q3YzU3NmM3OGIzZTNhNjYyMWIiLCJ7XCJpYXRcIjoxNjg4NTkyNjc5LFwiZXh0XCI6MTY4OTU5MjY3OSxcImlzc1wiOlwiZGlkOmV0aHI6MHhkZThiQUFBQzc1NzRENGE1ZGFCOTY0ZEFCMmUzYTA1YUVhYjc5ODU1XCIsXCJzdWJcIjpcIkV4WnEzdi1PZzZCcy1YQjFTVTVMSjVJV3VaNWVDa0JXekhYeldoNFJsUkk9XCIsXCJhdWRcIjpcIml6ZzhtSktnNGtFUG5nTHVYaExVUWdzRlJlaFhHYmZvVVhwQmhIaURxNlU9XCIsXCJuYmZcIjoxNjg4NTkyNjc5LFwidGlkXCI6XCIzNzhjNzhkYy0xNTBkLTQ0OGMtYjQ4MC1kNzY5N2EyZGUwNWVcIixcImFkZFwiOlwiMHg0MGM4MGMzNTRjOGIyZGZjOTNkYjI0MzlmNzgyNzQxNzdkMTk0MTA2Yjg2MmZlN2IwZDEwMTljNDY4OTFlMGUzN2EzMzNiMTA0ZmQ5YzFlMGUwNzgyOTcwZDRhMzM0ZmM2NTdlNjhjOTU4YTIyY2MwNzlmYjA3MmM3NzhkOTA5NjFjXCJ9Il0=')
```

### ⚠️ Update `CHANGELOG.md`

- [x] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
